### PR TITLE
Adapt CXCrossover and ScrambleMutation to TSP

### DIFF
--- a/examples/singleobjective/evolution_strategy/evolution_strategy_permutation.py
+++ b/examples/singleobjective/evolution_strategy/evolution_strategy_permutation.py
@@ -1,0 +1,27 @@
+from jmetal.algorithm.singleobjective.evolution_strategy import EvolutionStrategy
+from jmetal.operator.mutation import PermutationSwapMutation
+from jmetal.problem.singleobjective.tsp import TSP
+from jmetal.util.termination_criterion import StoppingByTime
+
+if __name__ == '__main__':
+    problem = TSP(instance='resources/TSP_instances/kroA100.tsp')
+
+    print(f"Solving TSP problem with {problem.number_of_cities} cities.")
+
+    algorithm = EvolutionStrategy(
+        problem=problem,
+        mu=1,
+        lambda_=10,
+        mutation=PermutationSwapMutation(1.0 / problem.number_of_cities),
+        elitist=False,
+        termination_criterion=StoppingByTime(10),
+    )
+
+    algorithm.run()
+    result = algorithm.get_result()
+
+    print(f'Algorithm: {algorithm.get_name()}')
+    print(f'Solution: {result.variables}')
+    print(f'The shortest path length: {result.objectives[0]}')
+    print(f'Computing time: {algorithm.total_computing_time}')
+    print(f'Number of evaluations: {algorithm.evaluations}')

--- a/examples/singleobjective/simulated_annealing/simulated_annealing_permutation.py
+++ b/examples/singleobjective/simulated_annealing/simulated_annealing_permutation.py
@@ -1,0 +1,24 @@
+from jmetal.algorithm.singleobjective.simulated_annealing import SimulatedAnnealing
+from jmetal.operator import ScrambleMutation
+from jmetal.problem import TSP
+from jmetal.util.termination_criterion import StoppingByTime
+
+if __name__ == '__main__':
+    problem = TSP(instance='resources/TSP_instances/kroA100.tsp')
+
+    print(f"Solving TSP problem with {problem.number_of_cities} cities.")
+
+    algorithm = SimulatedAnnealing(
+        problem=problem,
+        mutation=ScrambleMutation(probability=1.0 / problem.number_of_cities),
+        termination_criterion=StoppingByTime(max_seconds=10)
+    )
+
+    algorithm.run()
+    result = algorithm.get_result()
+
+    print(f'Algorithm: {algorithm.get_name()}')
+    print(f'Solution: {result.variables}')
+    print(f'The shortest path length:  {str(result.objectives[0])}')
+    print(f'Computing time: {str(algorithm.total_computing_time)}')
+    print(f'Problem evaluations: {str(algorithm.evaluations)}')

--- a/jmetal/operator/__init__.py
+++ b/jmetal/operator/__init__.py
@@ -1,13 +1,14 @@
-from .crossover import NullCrossover, SBXCrossover, SPXCrossover, DifferentialEvolutionCrossover
+from .crossover import NullCrossover, SBXCrossover, SPXCrossover, DifferentialEvolutionCrossover, \
+    PMXCrossover, CXCrossover
 from .mutation import NullMutation, BitFlipMutation, PolynomialMutation, IntegerPolynomialMutation, UniformMutation, \
-    SimpleRandomMutation
+    SimpleRandomMutation, ScrambleMutation, PermutationSwapMutation
 from .selection import BestSolutionSelection, BinaryTournamentSelection, BinaryTournament2Selection, \
     RandomSolutionSelection, NaryRandomSolutionSelection, RankingAndCrowdingDistanceSelection
 
 __all__ = [
-    'NullCrossover', 'SBXCrossover', 'SPXCrossover', 'DifferentialEvolutionCrossover',
+    'NullCrossover', 'SBXCrossover', 'SPXCrossover', 'DifferentialEvolutionCrossover', 'PMXCrossover', 'CXCrossover',
     'NullMutation', 'BitFlipMutation', 'PolynomialMutation', 'IntegerPolynomialMutation', 'UniformMutation',
-    'SimpleRandomMutation',
+    'SimpleRandomMutation', 'ScrambleMutation', 'PermutationSwapMutation',
     'BestSolutionSelection', 'BinaryTournamentSelection', 'BinaryTournament2Selection', 'RandomSolutionSelection',
     'NaryRandomSolutionSelection', 'RankingAndCrowdingDistanceSelection'
 ]

--- a/jmetal/operator/crossover.py
+++ b/jmetal/operator/crossover.py
@@ -120,7 +120,7 @@ class CXCrossover(Crossover[PermutationSolution, PermutationSolution]):
             for j in range(len(parents[0].variables)):
                 if j in cycle:
                     offspring[0].variables[j] = parents[0].variables[j]
-                    offspring[1].variables[j] = parents[0].variables[j]
+                    offspring[1].variables[j] = parents[1].variables[j]
 
         return offspring
 

--- a/jmetal/operator/crossover.py
+++ b/jmetal/operator/crossover.py
@@ -106,22 +106,21 @@ class CXCrossover(Crossover[PermutationSolution, PermutationSolution]):
         rand = random.random()
 
         if rand <= self.probability:
-            for i in range(parents[0].number_of_variables):
-                idx = random.randint(0, len(parents[0].variables[i]) - 1)
-                curr_idx = idx
-                cycle = []
+            idx = random.randint(0, len(parents[0].variables) - 1)
+            curr_idx = idx
+            cycle = []
 
-                while True:
-                    cycle.append(curr_idx)
-                    curr_idx = parents[0].variables[i].index(parents[1].variables[i][curr_idx])
+            while True:
+                cycle.append(curr_idx)
+                curr_idx = parents[0].variables.index(parents[1].variables[curr_idx])
 
-                    if curr_idx == idx:
-                        break
+                if curr_idx == idx:
+                    break
 
-                for j in range(len(parents[0].variables[i])):
-                    if j in cycle:
-                        offspring[0].variables[i][j] = parents[0].variables[i][j]
-                        offspring[1].variables[i][j] = parents[0].variables[i][j]
+            for j in range(len(parents[0].variables)):
+                if j in cycle:
+                    offspring[0].variables[j] = parents[0].variables[j]
+                    offspring[1].variables[j] = parents[0].variables[j]
 
         return offspring
 

--- a/jmetal/operator/mutation.py
+++ b/jmetal/operator/mutation.py
@@ -270,23 +270,22 @@ class CompositeMutation(Mutation[Solution]):
 class ScrambleMutation(Mutation[PermutationSolution]):
 
     def execute(self, solution: PermutationSolution) -> PermutationSolution:
-        for i in range(solution.number_of_variables):
-            rand = random.random()
+        rand = random.random()
 
-            if rand <= self.probability:
-                point1 = random.randint(0, len(solution.variables[i]))
-                point2 = random.randint(0, len(solution.variables[i]) - 1)
+        if rand <= self.probability:
+            point1 = random.randint(0, len(solution.variables))
+            point2 = random.randint(0, len(solution.variables) - 1)
 
-                if point2 >= point1:
-                    point2 += 1
-                else:
-                    point1, point2 = point2, point1
+            if point2 >= point1:
+                point2 += 1
+            else:
+                point1, point2 = point2, point1
 
-                if point2 - point1 >= 20:
-                    point2 = point1 + 20
+            if point2 - point1 >= 20:
+                point2 = point1 + 20
 
-                values = solution.variables[i][point1:point2]
-                solution.variables[i][point1:point2] = random.sample(values, len(values))
+            values = solution.variables[point1:point2]
+            solution.variables[point1:point2] = random.sample(values, len(values))
 
         return solution
 

--- a/jmetal/operator/test/test_crossover.py
+++ b/jmetal/operator/test/test_crossover.py
@@ -225,24 +225,20 @@ class CXTestCases(unittest.TestCase):
             CXCrossover(-12)
 
     @mock.patch('random.randint')
-    def test_should_the_operator_work_with_two_solutions_with_two_variables(self, random_call):
+    def test_should_the_operator_work_with_two_solutions_with_same_number_of_variables(self, random_call):
         operator = CXCrossover(1.0)
-        solution1 = PermutationSolution(number_of_variables=2, number_of_objectives=1)
-        solution1.variables[0] = [1, 2, 3, 4, 7]
-        solution1.variables[1] = [2, 6, 4, 5, 3]
+        solution1 = PermutationSolution(number_of_variables=5, number_of_objectives=1)
+        solution1.variables = [1, 2, 3, 4, 7]
 
-        solution2 = PermutationSolution(number_of_variables=2, number_of_objectives=1)
-        solution2.variables[0] = [2, 3, 4, 1, 9]
-        solution2.variables[1] = [5, 3, 2, 4, 6]
+        solution2 = PermutationSolution(number_of_variables=5, number_of_objectives=1)
+        solution2.variables = [2, 3, 4, 1, 9]
 
         random_call.return_value = 0
         offspring = operator.execute([solution1, solution2])
 
-        self.assertEqual([1, 2, 3, 4, 9], offspring[0].variables[0])
-        self.assertEqual([2, 3, 4, 5, 6], offspring[0].variables[1])
+        self.assertEqual([1, 2, 3, 4, 9], offspring[0].variables)
 
-        self.assertEqual([1, 2, 3, 4, 7], offspring[1].variables[0])
-        self.assertEqual([2, 6, 4, 5, 3], offspring[1].variables[1])
+        self.assertEqual([2, 3, 4, 1, 7], offspring[1].variables)
 
 
 class SBXCrossoverTestCases(unittest.TestCase):

--- a/jmetal/problem/__init__.py
+++ b/jmetal/problem/__init__.py
@@ -4,6 +4,7 @@ from .multiobjective.lz09 import LZ09_F2
 from .multiobjective.unconstrained import Kursawe, Fonseca, Schaffer, Viennet2
 from .multiobjective.zdt import ZDT1, ZDT2, ZDT3, ZDT4, ZDT6
 from .singleobjective.unconstrained import OneMax, Sphere
+from .singleobjective.tsp import TSP
 
 __all__ = [
     'Srinivas', 'Tanaka',
@@ -11,5 +12,6 @@ __all__ = [
     'DTLZ1', 'DTLZ2',
     'ZDT1', 'ZDT2', 'ZDT3', 'ZDT4', 'ZDT6',
     'LZ09_F2',
-    'OneMax', 'Sphere'
+    'OneMax', 'Sphere',
+    'TSP'
 ]


### PR DESCRIPTION
### Intent
1. Resolving the compatibility problem mentioned in #68; 
2. Adding TSP examples for SA and ES algorithms;
3. Adding a small fix in CXCrossover.

### Remarks
1. Unfortunately I did not find an elegant solution for permutation operators cases, when the variables are nested lists (originally I was thinking of using *numpy.apply_along_axis*) therefore, I simply rejected this use-case since, the framework does not contain such optimization problems.

3. 2nd child should use cycle values from 2nd parent, if I understand it correctly. [Current](
https://github.com/jMetal/jMetalPy/blob/master/jmetal/operator/crossover.py#L124) CXCrossover implementation results in 2nd offspring creation as a copy of 1st parent.

