### PR TITLE
Rename master to main in contributing docs

### DIFF
--- a/docs/_sources/contributing.rst.txt
+++ b/docs/_sources/contributing.rst.txt
@@ -11,10 +11,10 @@ We have a set of branches on the remote Git server.
 Some branches are temporary, and others are constant throughout the life of the repository.
 
 * Branches always present in the repository:
-    * *master*: You have the latest released to production, receive merges from the develop branch, or merge from a *hotfix* branch (emergency).
-        * Do I have to put a TAG when doing a merge from develop to master? yes
-        * Do I have to put a TAG when doing a merge from a hotfix branch to master? yes
-        * After merge from a hotfix to master, do I have to merge from master to develop? yes
+    * *main*: You have the latest released to production, receive merges from the develop branch, or merge from a *hotfix* branch (emergency).
+        * Do I have to put a TAG when doing a merge from develop to main? yes
+        * Do I have to put a TAG when doing a merge from a hotfix branch to main? yes
+        * After merge from a hotfix to main, do I have to merge from main to develop? yes
     * *develop*: It is considered the "Next Release", receives merges from branches of each developer, either corrections (*fix*) or new features (*feature*).
 
 * Temporary branches:
@@ -27,8 +27,8 @@ Some branches are temporary, and others are constant throughout the life of the 
         * When I finish the correction in my fix branch, which branch to merge into?: You always merge feature branch into develop branch
 
     * *hotfix/\<task\-id\>\-\<description\>*: When we are correcting an emergency incidence in production, we create a local branch with the prefix "hotfix/", then only if there is a task id, we indicate it and we add a hyphen. The following we indicate a description according to the functionality that we are correcting. The words are separated by hyphens.
-        * Where does this branch emerge?: This branch always emerge from the master branch
-        * When I finish the correction in my hotfix branch, which branch to merge into?: This branch always emerge from the master and develop branch
+        * Where does this branch emerge?: This branch always emerge from the main branch
+        * When I finish the correction in my hotfix branch, which branch to merge into?: This branch always emerge from the main and develop branch
 
 * Steps to follow when you are creating or going to work on a branch of any kind (feature / fix / hotfix):
     1. After you create your branch (feature / fix / hotfix) locally, upload it to the remote Git server. The integration system will verify your code from the outset.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -11,10 +11,10 @@ We have a set of branches on the remote Git server.
 Some branches are temporary, and others are constant throughout the life of the repository.
 
 * Branches always present in the repository:
-    * *master*: You have the latest released to production, receive merges from the develop branch, or merge from a *hotfix* branch (emergency).
-        * Do I have to put a TAG when doing a merge from develop to master? yes
-        * Do I have to put a TAG when doing a merge from a hotfix branch to master? yes
-        * After merge from a hotfix to master, do I have to merge from master to develop? yes
+    * *main*: You have the latest released to production, receive merges from the develop branch, or merge from a *hotfix* branch (emergency).
+        * Do I have to put a TAG when doing a merge from develop to main? yes
+        * Do I have to put a TAG when doing a merge from a hotfix branch to main? yes
+        * After merge from a hotfix to main, do I have to merge from main to develop? yes
     * *develop*: It is considered the "Next Release", receives merges from branches of each developer, either corrections (*fix*) or new features (*feature*).
 
 * Temporary branches:
@@ -27,8 +27,8 @@ Some branches are temporary, and others are constant throughout the life of the 
         * When I finish the correction in my fix branch, which branch to merge into?: You always merge feature branch into develop branch
 
     * *hotfix/\<task\-id\>\-\<description\>*: When we are correcting an emergency incidence in production, we create a local branch with the prefix "hotfix/", then only if there is a task id, we indicate it and we add a hyphen. The following we indicate a description according to the functionality that we are correcting. The words are separated by hyphens.
-        * Where does this branch emerge?: This branch always emerge from the master branch
-        * When I finish the correction in my hotfix branch, which branch to merge into?: This branch always emerge from the master and develop branch
+        * Where does this branch emerge?: This branch always emerge from the main branch
+        * When I finish the correction in my hotfix branch, which branch to merge into?: This branch always emerge from the main and develop branch
 
 * Steps to follow when you are creating or going to work on a branch of any kind (feature / fix / hotfix):
     1. After you create your branch (feature / fix / hotfix) locally, upload it to the remote Git server. The integration system will verify your code from the outset.


### PR DESCRIPTION
What is the reason for the duplicated documents? I just fixed the branch name in both of them, but I'm still wondering why.