### PR TITLE
Fix PMXCrossover - don't create child that has references to parents

### DIFF
--- a/jmetal/operator/crossover.py
+++ b/jmetal/operator/crossover.py
@@ -83,7 +83,7 @@ class PMXCrossover(Crossover[PermutationSolution, PermutationSolution]):
                                 swapped[i_son][i_chromosome] = map_[1 - i_son][map_index]
                 return s1, s2
 
-            swapped = _swap(parents[0].variables, parents[1].variables, cross_points)
+            swapped = _swap(offspring[0].variables, offspring[1].variables, cross_points)
             mapped = _map(swapped, cross_points)
 
             offspring[0].variables, offspring[1].variables = mapped


### PR DESCRIPTION
Previously the `PMXCrossover.execute` function was returning a child solution with `variables` field referring to parts of parents' `variables`. It is due to `variables` being a list of lists, so the slice operator in `_swap` function was just copying the references of the lists in the list.

It resulted in unexpected behaviours like child mutation affecting its parents, which led to e.g. wrong solutions being reported as best.